### PR TITLE
「すべての Msg Tool を閉じる」が正しく動いていないバグを修正

### DIFF
--- a/src/content_scripts/actions/lVAllMsgs.ts
+++ b/src/content_scripts/actions/lVAllMsgs.ts
@@ -2,7 +2,8 @@ import selectors from '../selectors';
 import { mouseleave } from './utils/dispatchEvent';
 
 const lVAllMsgs = () => {
-  document.body.click();
+  document.body.dispatchEvent(new MouseEvent('mousedown'));
+  document.body.dispatchEvent(new MouseEvent('mouseup'));
 
   const messageListSelector = selectors.channelViewMsgList();
   if (!messageListSelector) return;


### PR DESCRIPTION
traQ_S-UI v3.19.0 のアップデート (もっと細かく言うと https://github.com/traPtitech/traQ_S-UI/pull/4119) でスタンプピッカーなどのツールを閉じる動作が`document.body.click()`ではできなくなったので修正しました