### PR TITLE
オプションページのタイミングを拡張機能のインストール時とアップデート時に制限する

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,9 +1,11 @@
 import browser from 'webextension-polyfill';
 
-browser.runtime.onInstalled.addListener(() => {
-  browser.runtime.openOptionsPage();
-  // Page actions are disabled by default and enabled on select tabs
-  browser.action.disable();
+browser.runtime.onInstalled.addListener(({ reason }) => {
+  if (reason === "install" || reason === "update") {
+    browser.runtime.openOptionsPage();
+    // Page actions are disabled by default and enabled on select tabs
+    browser.action.disable();
+  }
 
   // Clear all rules to ensure only our expected rules are set
   browser.declarativeContent.onPageChanged.removeRules(undefined, () => {


### PR DESCRIPTION
ブラウザのアプデ時に開かれることが多かったので制限しました

参考: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/OnInstalledReason 

確認したこと

- [x] 手元のブラウザ(edge)でインストール時に正常に開かれること
- [x] 読み込み時にエラーが出ていないこと